### PR TITLE
[TASK] Allow using TYPO3 "12.4.x@dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,13 @@
         "source": "https://github.com/typo3/typo3"
     },
     "require": {
-        "typo3/cms-backend": "^12.4",
-        "typo3/cms-core": "^12.4",
-        "typo3/cms-extbase": "^12.4",
-        "typo3/cms-extensionmanager": "^12.4",
-        "typo3/cms-filelist": "^12.4",
-        "typo3/cms-fluid": "^12.4",
-        "typo3/cms-frontend": "^12.4",
-        "typo3/cms-install": "^12.4"
+        "typo3/cms-backend": "12.4.x@dev",
+        "typo3/cms-core": "12.4.x@dev",
+        "typo3/cms-extbase": "12.4.x@dev",
+        "typo3/cms-extensionmanager": "12.4.x@dev",
+        "typo3/cms-filelist": "12.4.x@dev",
+        "typo3/cms-fluid": "12.4.x@dev",
+        "typo3/cms-frontend": "12.4.x@dev",
+        "typo3/cms-install": "12.4.x@dev"
     }
 }


### PR DESCRIPTION
Currently `composer req typo3/minimal:12.4.x@dev` would still install TYPO3 packages in version `12.4.4` instead of `12.4.x@dev`.