### PR TITLE
[TASK] Avoid typo3/cms-extensionmanager

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "typo3/cms-backend": "dev-main",
         "typo3/cms-core": "dev-main",
         "typo3/cms-extbase": "dev-main",
-        "typo3/cms-extensionmanager": "dev-main",
         "typo3/cms-filelist": "dev-main",
         "typo3/cms-fluid": "dev-main",
         "typo3/cms-frontend": "dev-main",


### PR DESCRIPTION
The EM is pretty much useless in composer based
TYPO3 instances and v13 removed dependencies to
it in other extensions. It should no longer be
part of the minimal package.