### PR TITLE
[TASK] Avoid typo3/cms-install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "typo3/cms-extensionmanager": "dev-main",
         "typo3/cms-filelist": "dev-main",
         "typo3/cms-fluid": "dev-main",
-        "typo3/cms-frontend": "dev-main",
-        "typo3/cms-install": "dev-main"
+        "typo3/cms-frontend": "dev-main"
     }
 }


### PR DESCRIPTION
TYPO3 v13 no longer hard requires EXT:install. In the spirit of a "minimal" meta package, it should no
longer be part of composer.json.

Deploying production systems without the install tool raises security, since not existing code can not have security issues.

Instances that manage good deployment chains and can deal with a missing EXT:install during upgrades
(or have it loaded temporarily, or only on some of multiple production servers), should have the
opportunity to do so.