### PR TITLE
[TASK] Adjust for TYPO3 v13.4 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,11 @@
         "news": "nntp://lists.typo3.org"
     },
     "require": {
-        "typo3/cms-backend": "13.1.x@dev",
-        "typo3/cms-core": "13.1.x@dev",
-        "typo3/cms-extbase": "13.1.x@dev",
-        "typo3/cms-filelist": "13.1.x@dev",
-        "typo3/cms-fluid": "13.1.x@dev",
-        "typo3/cms-frontend": "13.1.x@dev"
+        "typo3/cms-backend": "^13.4",
+        "typo3/cms-core": "^13.4",
+        "typo3/cms-extbase": "^13.4",
+        "typo3/cms-filelist": "^13.4",
+        "typo3/cms-fluid": "^13.4",
+        "typo3/cms-frontend": "^13.4"
     }
 }


### PR DESCRIPTION
To be released as tag `v13.4.0` with release headline "Release v13.4 LTS"